### PR TITLE
Add curses to runtime dependency

### DIFF
--- a/tplot.gemspec
+++ b/tplot.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |gem|
   gem.name          = "tplot"
   gem.require_paths = ["lib"]
   gem.version       = Tplot::VERSION
+
+  gem.add_runtime_dependency "curses"
 end


### PR DESCRIPTION
Hi, I tried tplot.

tplot makes use of curses.
But curses is not currently bundled in Ruby anymore.

In this pull request, I have included curses in the gemspec as a dependency gem for tplot. This will allow tplot to work properly.

Thank you.
